### PR TITLE
feat: insert issue ticket ID from branch name into commit message

### DIFF
--- a/package.json
+++ b/package.json
@@ -444,6 +444,12 @@
           "markdownDescription": "Prompt for entering refs (e.g., issue numbers) when generating commit messages. **Note:** this may interrupt automatic flow if `#commitSage.commit.autoCommit#` is enabled.",
           "order": 10
         },
+        "commitSage.commit.insertTicketId": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Extract an issue ticket ID (e.g. `PROJ-123`, `ABC-456`) from the current Git branch name and insert it into the generated commit message.\n\n- **Formats with scope** (`conventional`, `angular`, `karma`, `google`, `emoji`, `emojiKarma`): inserts the ID as the scope → `feat(PROJ-123): description`.\n- **Formats without scope** (`semantic`, `atom`, `detailed`): prepends the ID to the description → `feat: PROJ-123 description`.\n\nThe ID is also included as a mandatory instruction in the LLM prompt, with a programmatic fallback that injects it if the model omits it.",
+          "order": 11
+        },
         "commitSage.gemini.model": {
           "type": "string",
           "default": "auto",

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -40,6 +40,7 @@ export interface ProjectConfig {
         autoCommit?: boolean;
         autoPush?: boolean;
         promptForRefs?: boolean;
+        insertTicketId?: boolean;
         commitlint?: {
             enabled?: boolean;
             maxRetries?: number;

--- a/src/services/commitWorkflow.ts
+++ b/src/services/commitWorkflow.ts
@@ -10,6 +10,8 @@ import { ApiKeyManager } from './apiKeyManager';
 import { UserCancelledError, ApiKeyInvalidError } from '../models/errors';
 import { toError, sanitizeErrorForTelemetry } from '../utils/errorUtils';
 import { mapLimit } from '../utils/concurrency';
+import { extractTicketId, injectTicketIntoMessage } from '../utils/ticketUtils';
+import { getTicketPlacement } from '../templates';
 
 const BLAME_CONCURRENCY = 8;
 
@@ -169,6 +171,15 @@ export class CommitWorkflow {
             onlyStagedChanges: useStagedChanges,
             signal,
         });
+
+        if (ConfigService.get('commit.insertTicketId')) {
+            const branchName = await GitService.getBranchName(repoPath, signal);
+            const ticket = extractTicketId(branchName);
+            if (ticket) {
+                const placement = getTicketPlacement(ConfigService.get('commit.commitFormat'));
+                commitMessage.message = injectTicketIntoMessage(commitMessage.message, ticket, placement);
+            }
+        }
 
         sourceControlRepository.inputBox.value = commitMessage.message;
 

--- a/src/services/gitService.ts
+++ b/src/services/gitService.ts
@@ -452,6 +452,14 @@ export class GitService {
     return validDiffs.length > 0 ? '# Deleted files:\n' + validDiffs.join('\n') : '';
   }
 
+  static async getBranchName(repoPath: string, signal?: AbortSignal): Promise<string> {
+    try {
+      return (await this.executeGitCommand(['rev-parse', '--abbrev-ref', 'HEAD'], repoPath, signal)).trim();
+    } catch {
+      return '';
+    }
+  }
+
   public static async hasHead(repoPath: string, signal?: AbortSignal): Promise<boolean> {
     try {
       await this.execGit(['rev-parse', 'HEAD'], repoPath, { signal });

--- a/src/services/promptService.ts
+++ b/src/services/promptService.ts
@@ -1,7 +1,9 @@
-import { CommitFormat, getTemplate } from '../templates';
+import { CommitFormat, getTemplate, getTicketPlacement } from '../templates';
 import { ConfigService } from '../utils/configService';
 import { CommitLintService, CommitLintEngine } from './commitLintService';
 import { CustomLanguageService } from './customLanguageService';
+import { GitService } from './gitService';
+import { extractTicketId } from '../utils/ticketUtils';
 import type { CommitLanguage } from '../utils/constants';
 import type { ProgressReporter } from '../models/types';
 
@@ -72,12 +74,34 @@ Please provide ONLY the commit message, without any additional text or explanati
 `;
     }
 
+    private static async resolveTicketInstruction(repoPath: string, formatSetting: string): Promise<string> {
+        if (!ConfigService.get('commit.insertTicketId')) {
+            return '';
+        }
+        const branchName = await GitService.getBranchName(repoPath);
+        const ticket = extractTicketId(branchName);
+        if (!ticket) {
+            return '';
+        }
+        const placement = getTicketPlacement(formatSetting);
+        if (placement === 'scope') {
+            return `MANDATORY: Use "${ticket}" as the commit scope. The first line MUST follow this pattern: type(${ticket}): description.`;
+        }
+        return `MANDATORY: Start the description with "${ticket}". The first line MUST follow this pattern: type: ${ticket} description.`;
+    }
+
     static async generatePrompt(repoPath: string, diff: string, blameAnalysis: string, progress: ProgressReporter): Promise<string> {
         const useCustomInstructions = ConfigService.get('commit.useCustomInstructions');
         const customInstructions = ConfigService.get('commit.customInstructions');
+        const formatSetting = ConfigService.get('commit.commitFormat');
+
+        const ticketInstruction = await this.resolveTicketInstruction(repoPath, formatSetting);
 
         if (useCustomInstructions && customInstructions.trim()) {
-            return `${customInstructions}
+            const base = ticketInstruction
+                ? `${customInstructions}\n\n${ticketInstruction}`
+                : customInstructions;
+            return `${base}
 
 Git diff to analyze:
 ${diff}
@@ -90,7 +114,6 @@ ${STRICT_FORMAT_REMINDER}
 Please provide ONLY the commit message, without any additional text or explanations.`;
         }
 
-        const formatSetting = ConfigService.get('commit.commitFormat');
         const format = formatSetting as CommitFormat;
 
         const { template, languagePrompt } = await this.resolveLanguagePrompt(format, progress);
@@ -106,6 +129,9 @@ Please provide ONLY the commit message, without any additional text or explanati
             const rules = await CommitLintService.extractRules(repoPath, rulesPath, { engine, format: formatSetting });
             mainInstructions = `${template}\n\n${rules}`;
         }
+
+        // Resolve the {{TICKET_ID}} placeholder appended by getTemplate().
+        mainInstructions = mainInstructions.replace('{{TICKET_ID}}', ticketInstruction);
 
         return this.buildPrompt(mainInstructions, languagePrompt, diff, blameAnalysis, reminder);
     }

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -15,6 +15,26 @@ type CommitTemplate = Record<Exclude<CommitLanguage, 'custom'>, string>;
 
 export type CommitFormat = 'conventional' | 'angular' | 'karma' | 'semantic' | 'emoji' | 'emojiKarma' | 'google' | 'atom' | 'detailed';
 
+/**
+ * Defines where a ticket ID (e.g. PROJ-123) is placed in the commit header
+ * for each format. 'scope' → type(TICKET): desc; 'prefix' → type: TICKET desc.
+ */
+const TICKET_PLACEMENT: Record<CommitFormat, 'scope' | 'prefix'> = {
+    conventional: 'scope',
+    angular:      'scope',
+    karma:        'scope',
+    google:       'scope',
+    emoji:        'scope',
+    emojiKarma:   'scope',
+    semantic:     'prefix',
+    atom:         'prefix',
+    detailed:     'prefix',
+};
+
+export function getTicketPlacement(format: string): 'scope' | 'prefix' {
+    return TICKET_PLACEMENT[format as CommitFormat] ?? 'scope';
+}
+
 const templates: Record<CommitFormat, CommitTemplate> = {
     conventional: conventionalTemplate,
     angular: angularTemplate,
@@ -43,12 +63,16 @@ export function getTemplate(format: CommitFormat, language: CommitLanguage): str
 
     const template = templates[format];
 
-    if (!isValidLanguage(language)) {
-        if (language !== 'custom') {
-            Logger.warn(`Invalid language "${language}", falling back to english`);
-        }
-        return template.english;
-    }
+    const body = isValidLanguage(language)
+        ? template[language]
+        : (() => {
+            if (language !== 'custom') {
+                Logger.warn(`Invalid language "${language}", falling back to english`);
+            }
+            return template.english;
+        })();
 
-    return template[language];
+    // Placeholder resolved by PromptService: replaced with a ticket-ID
+    // instruction when commit.insertTicketId is enabled, removed otherwise.
+    return `${body}\n\n{{TICKET_ID}}`;
 }

--- a/src/utils/configService.ts
+++ b/src/utils/configService.ts
@@ -61,6 +61,7 @@ export const SETTING_DEFAULTS = {
     'commit.commitlint.maxRetries': 3,
     'commit.commitlint.rulesPath': '',
     'commit.commitlint.engine': 'builtin',
+    'commit.insertTicketId': false,
 } as const satisfies Record<string, CacheValue>;
 /* eslint-enable @typescript-eslint/naming-convention */
 

--- a/src/utils/ticketUtils.ts
+++ b/src/utils/ticketUtils.ts
@@ -1,0 +1,66 @@
+// Matches common issue tracker ticket IDs: PROJECT-123, ABC-456, etc.
+// Works with Jira, Linear, GitHub Projects labels, and similar conventions.
+const TICKET_PATTERN = /\b([A-Z][A-Z0-9]*-[0-9]+)\b/;
+
+export function extractTicketId(branchName: string): string | null {
+    const match = TICKET_PATTERN.exec(branchName);
+    return match ? match[1] : null;
+}
+
+/**
+ * Injects `ticket` into the first line of `message`.
+ *
+ * - `scope`: inserts as conventional-commit scope → `type(TICKET): desc`.
+ *   Also handles emoji-prefixed headers → `:emoji: type(TICKET): desc`.
+ *   If a scope already exists it is replaced with the ticket ID.
+ * - `prefix`: inserts right after the first `: ` → `type: TICKET desc`.
+ *   Works for semantic, atom, detailed, and similar formats.
+ *
+ * Returns the message unchanged when the ticket is already present or the
+ * header does not match the expected pattern.
+ */
+export function injectTicketIntoMessage(
+    message: string,
+    ticket: string,
+    placement: 'scope' | 'prefix',
+): string {
+    const lines = message.split('\n');
+    const header = lines[0];
+
+    if (placement === 'scope') {
+        // Standard conventional header: type(scope)!?: description
+        const std = /^(\w+)(\(([^)]*)\))?(!)?(:\s*)(.*)$/.exec(header);
+        if (std) {
+            const [, type, , existingScope, bang, colon, desc] = std;
+            if (existingScope === ticket) {
+                return message;
+            }
+            lines[0] = `${type}(${ticket})${bang ?? ''}${colon}${desc}`;
+            return lines.join('\n');
+        }
+
+        // Emoji-prefixed header: :emoji: type(scope)!?: description
+        const emoji = /^(:[a-z_]+:\s*)(\w+)(\(([^)]*)\))?(!)?(:\s*)(.*)$/.exec(header);
+        if (emoji) {
+            const [, emojiToken, type, , existingScope, bang, colon, desc] = emoji;
+            if (existingScope === ticket) {
+                return message;
+            }
+            lines[0] = `${emojiToken}${type}(${ticket})${bang ?? ''}${colon}${desc}`;
+            return lines.join('\n');
+        }
+
+        return message;
+    }
+
+    // prefix placement — insert ticket right after the first ': '
+    if (header.includes(ticket)) {
+        return message;
+    }
+    const colonIdx = header.indexOf(': ');
+    if (colonIdx === -1) {
+        return message;
+    }
+    lines[0] = `${header.slice(0, colonIdx + 2)}${ticket} ${header.slice(colonIdx + 2)}`;
+    return lines.join('\n');
+}

--- a/src/views/settingsWebviewProvider.ts
+++ b/src/views/settingsWebviewProvider.ts
@@ -104,6 +104,7 @@ const SETTING_KEYS = {
     commitlintMaxRetries: 'commitSage.commit.commitlint.maxRetries',
     commitlintRulesPath: 'commitSage.commit.commitlint.rulesPath',
     commitlintEngine: 'commitSage.commit.commitlint.engine',
+    insertTicketId: 'commitSage.commit.insertTicketId',
 } as const;
 
 interface ModelSlot {
@@ -139,6 +140,7 @@ interface ViewState {
         commitlintRulesPath: string;
         commitlintEngine: string;
         commitlintCliAvailable: boolean;
+        insertTicketId: boolean;
     };
     advanced: {
         apiRequestTimeout: number;
@@ -488,6 +490,7 @@ export class SettingsWebviewProvider implements vscode.WebviewViewProvider {
                     const root = ConfigService.getProjectRootPath();
                     return root ? CommitLintCliService.detect(root) !== null : false;
                 })(),
+                insertTicketId: ConfigService.get('commit.insertTicketId'),
             },
             advanced: {
                 apiRequestTimeout: ConfigService.get('apiRequestTimeout'),
@@ -719,6 +722,8 @@ export class SettingsWebviewProvider implements vscode.WebviewViewProvider {
                 commitlintRulesPath: vscode.l10n.t('Commitlint rules path'),
                 enableCustom: vscode.l10n.t('Enable custom instructions'),
                 customInstructionsPh: vscode.l10n.t('Free-form text appended to the prompt — e.g. ticket-tag conventions.'),
+                insertTicketId: vscode.l10n.t('Insert issue ticket ID'),
+                insertTicketIdHint: vscode.l10n.t('Extracts a ticket ID from the branch name (e.g. PROJ-123) and inserts it as the scope (conventional/angular/karma) or as a description prefix (semantic/atom/detailed).'),
                 advanced: vscode.l10n.t('Advanced'),
                 apiTimeout: vscode.l10n.t('API request timeout (seconds)'),
                 gitTimeout: vscode.l10n.t('Git timeout (seconds)'),

--- a/src/views/webview/main.ts
+++ b/src/views/webview/main.ts
@@ -72,6 +72,8 @@ interface InitData {
         commitlintRulesPath: string;
         enableCustom: string;
         customInstructionsPh: string;
+        insertTicketId: string;
+        insertTicketIdHint: string;
         advanced: string;
         apiTimeout: string;
         gitTimeout: string;
@@ -115,6 +117,7 @@ interface ViewState {
         commitlintRulesPath: string;
         commitlintEngine: string;
         commitlintCliAvailable: boolean;
+        insertTicketId: boolean;
     };
     advanced: {
         apiRequestTimeout: number;
@@ -837,6 +840,14 @@ function renderCommitSection(state: ViewState): HTMLElement {
         L.onlyStaged,
         state.commit.onlyStagedChanges,
         v => setSetting(KEYS.onlyStagedChanges, v),
+    ));
+
+    body.appendChild(makeCheckbox(
+        'insert-ticket-id',
+        L.insertTicketId,
+        state.commit.insertTicketId,
+        v => setSetting(KEYS.insertTicketId, v),
+        { hint: L.insertTicketIdHint },
     ));
 
     return section('commit', L.commit, true, body);


### PR DESCRIPTION
Summary

  - Adds a new boolean setting commitSage.commit.insertTicketId (default: false) that extracts an issue tracker ticket ID from the current Git branch name (e.g. PROJ-123, ABC-456) and
  injects it into the generated commit message.
  - Format-aware placement: scope for conventional, angular, karma, google, emoji, emojiKarma → feat(PROJ-123): description; prefix for semantic, atom, detailed → feat: PROJ-123 
  description.
  - Two-layer guarantee: the ticket ID is added as a mandatory instruction in the LLM prompt and applied programmatically as a safety net if the model omits it.
  - Fails silently when git is unavailable or the branch has no recognizable ticket ID — the feature self-disables without error.
  - Pattern is tracker-agnostic ([A-Z][A-Z0-9]*-[0-9]+): works with Jira, Linear, GitHub Projects labels, and similar conventions.

  Changes

  - src/utils/ticketUtils.ts (new) — extractTicketId() (regex extraction from branch name) and injectTicketIntoMessage() (format-aware, handles standard and emoji-prefixed headers).
  - src/templates/index.ts — TICKET_PLACEMENT map per format, getTicketPlacement() export, and {{TICKET_ID}} placeholder appended to every template string by getTemplate().
  - src/services/promptService.ts — resolveTicketInstruction() resolves the placeholder into a mandatory instruction (or removes it); applied to both template and custom-instructions
  paths.
  - src/services/commitWorkflow.ts — post-generation safety net that calls injectTicketIntoMessage() if the LLM ignored the prompt instruction.
  - src/services/gitService.ts — getBranchName() method (wraps git rev-parse --abbrev-ref HEAD, returns '' on any failure).
  - src/views/settingsWebviewProvider.ts + src/views/webview/main.ts — setting exposed in the Commit message section of the settings panel with a descriptive hint.
  - package.json + src/utils/configService.ts + src/models/types.ts — schema, default value, and ProjectConfig type updated.